### PR TITLE
ENG-12957: Add section for S3 File Browser configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Learn more in the [sidecar upgrade procedures](https://cyral.com/docs/sidecars/m
 
 Instructions for advanced configurations are available for the following topics:
 
+* [Enable the S3 File Browser](./docs/s3-browser.md)
 * [Expose to the Internet](./docs/public-load-balancer.md)
 * [Node scheduling](./docs/node-scheduling.md)
 * [Restrict repositories' ports](./docs/port-configuration.md)
@@ -214,4 +215,3 @@ Instructions for advanced configurations are available for the following topics:
 * [Sidecar instance metrics](./docs/metrics.md)
 * [Use a pre-existing service account](./docs/pre-existing-sa.md)
 * [Values file reference](./docs/values-file.md)
-* [Enable the S3 File Browser](./docs/s3-browser.md)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ as part of the [repository configuration](https://cyral.com/docs/manage-reposito
 
 See the next section for more details about the values file parameters.
 
+#### Enable the S3 File Browser
+
+To configure the sidecar to work on the S3 File Browser, set the following extra parameters under the service key of your values file:
+
+```
+service:
+  dnsName: "<CNAME>" # ex: "www.sidecar-custom-name.com"
+  loadBalancer:
+    tlsPorts: [443]
+    certificateId: "arn:aws:acm:<REGION>:<AWS_ACCOUNT>:certificate/<CERTIFICATE_ID>"
+```
+
+For the helm template, there is no equivalent to the terraform’s
+`sidecar_dns_hosted_zone_id` variable. It means the CNAME will need to
+be created after the deployment. See [Add a CNAME or A record for the
+sidecar](https://cyral.com/docs/sidecars/manage/alias).
+
+All the Helm parameters used above are documented in the 
+[values file configuration reference](./docs/values-file.md). 
+For more details about the S3 File Browser configuration, check the 
+[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
+documentation.
+
 ### Parameters
 
 See the full list of parameters in the [values file configuration reference](./docs/values-file.md).

--- a/README.md
+++ b/README.md
@@ -174,29 +174,6 @@ as part of the [repository configuration](https://cyral.com/docs/manage-reposito
 
 See the next section for more details about the values file parameters.
 
-#### Enable the S3 File Browser
-
-To configure the sidecar to work on the S3 File Browser, set the following extra parameters under the service key of your values file:
-
-```
-service:
-  dnsName: "<CNAME>" # ex: "www.sidecar-custom-name.com"
-  loadBalancer:
-    tlsPorts: [443]
-    certificateId: "arn:aws:acm:<REGION>:<AWS_ACCOUNT>:certificate/<CERTIFICATE_ID>"
-```
-
-For the helm template, there is no equivalent to the terraform’s
-`sidecar_dns_hosted_zone_id` variable. It means the CNAME will need to
-be created after the deployment. See [Add a CNAME or A record for the
-sidecar](https://cyral.com/docs/sidecars/manage/alias).
-
-All the Helm parameters used above are documented in the 
-[values file configuration reference](./docs/values-file.md). 
-For more details about the S3 File Browser configuration, check the 
-[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
-documentation.
-
 ### Parameters
 
 See the full list of parameters in the [values file configuration reference](./docs/values-file.md).
@@ -237,3 +214,4 @@ Instructions for advanced configurations are available for the following topics:
 * [Sidecar instance metrics](./docs/metrics.md)
 * [Use a pre-existing service account](./docs/pre-existing-sa.md)
 * [Values file reference](./docs/values-file.md)
+* [Enable the S3 File Browser](./docs/s3-browser.md)

--- a/docs/s3-browser.md
+++ b/docs/s3-browser.md
@@ -10,10 +10,9 @@ service:
     certificateId: "arn:aws:acm:<REGION>:<AWS_ACCOUNT>:certificate/<CERTIFICATE_ID>"
 ```
 
-For the helm template, there is no equivalent to the terraform’s
-`sidecar_dns_hosted_zone_id` variable. It means the CNAME will need to
-be created after the deployment. See [Add a CNAME or A record for the
-sidecar](https://cyral.com/docs/sidecars/manage/alias).
+The CNAME provided in `service.dnsName` must be created
+after the deployment pointing to the sidecar load balancer.
+See [Add a CNAME or A record for the sidecar](https://cyral.com/docs/sidecars/manage/alias).
 
 All the Helm parameters used above are documented in the 
 [values file configuration reference](./values-file.md). 

--- a/docs/s3-browser.md
+++ b/docs/s3-browser.md
@@ -16,7 +16,7 @@ be created after the deployment. See [Add a CNAME or A record for the
 sidecar](https://cyral.com/docs/sidecars/manage/alias).
 
 All the Helm parameters used above are documented in the 
-[values file configuration reference](./docs/values-file.md). 
+[values file configuration reference](./values-file.md). 
 For more details about the S3 File Browser configuration, check the 
 [Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
 documentation.

--- a/docs/s3-browser.md
+++ b/docs/s3-browser.md
@@ -1,0 +1,22 @@
+#### Enable the S3 File Browser
+
+To configure the sidecar to work on the S3 File Browser, set the following extra parameters under the service key of your values file:
+
+```
+service:
+  dnsName: "<CNAME>" # ex: "sidecar.custom-domain.com"
+  loadBalancer:
+    tlsPorts: [443]
+    certificateId: "arn:aws:acm:<REGION>:<AWS_ACCOUNT>:certificate/<CERTIFICATE_ID>"
+```
+
+For the helm template, there is no equivalent to the terraform’s
+`sidecar_dns_hosted_zone_id` variable. It means the CNAME will need to
+be created after the deployment. See [Add a CNAME or A record for the
+sidecar](https://cyral.com/docs/sidecars/manage/alias).
+
+All the Helm parameters used above are documented in the 
+[values file configuration reference](./docs/values-file.md). 
+For more details about the S3 File Browser configuration, check the 
+[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
+documentation.


### PR DESCRIPTION
Add a section for S3 File Browser configuration, instructing how to configure the corresponding sidecar template parameters to work with S3 File Browser.